### PR TITLE
Remove obsolete profile badges

### DIFF
--- a/assets/css/profile-page.css
+++ b/assets/css/profile-page.css
@@ -36,21 +36,6 @@
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
 }
 
-.profile-badge {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-  background: #4CAF50;
-  color: white;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 3px solid white;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-}
 
 .profile-name {
   font-size: 2.2rem;

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -97,21 +97,6 @@ body {
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1) !important;
 }
 
-.profile-badge {
-  position: absolute !important;
-  bottom: 10px !important;
-  right: 10px !important;
-  background: #2563eb !important;
-  color: white !important;
-  width: 30px !important;
-  height: 30px !important;
-  border-radius: 50% !important;
-  display: flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  font-size: 14px !important;
-  border: 3px solid #ffffff !important;
-}
 
 /* Profile Information */
 .profile-info {

--- a/content/home/index.md
+++ b/content/home/index.md
@@ -19,9 +19,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="/my-avatar.jpg" alt="Dr. Mingshu Wang" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Dr. Mingshu Wang</h1>

--- a/content/people/cai-wu/index.md
+++ b/content/people/cai-wu/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Cai Wu" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Dr. Cai Wu</h1>

--- a/content/people/dr-mingshu-wang/index.md
+++ b/content/people/dr-mingshu-wang/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-new.jpg" alt="Dr. Mingshu Wang" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Dr. Mingshu Wang</h1>

--- a/content/people/heyi-wei/index.md
+++ b/content/people/heyi-wei/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Heyi Wei" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Dr. Heyi Wei</h1>

--- a/content/people/nana-lin/index.md
+++ b/content/people/nana-lin/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Nana Lin" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Dr. Nana Lin</h1>

--- a/content/people/rui-deng/index.md
+++ b/content/people/rui-deng/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Rui Deng" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Rui Deng</h1>

--- a/content/people/xinyan-xian/index.md
+++ b/content/people/xinyan-xian/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Xinyan Xian" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Xinyan Xian</h1>

--- a/content/people/xinyi-yuan/index.md
+++ b/content/people/xinyi-yuan/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Xinyan Yuan" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Xinyan Yuan</h1>

--- a/content/people/yue-li/index.md
+++ b/content/people/yue-li/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Yue Li" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Yue Li</h1>

--- a/content/people/yue/index.md
+++ b/content/people/yue/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Yue" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Yue</h1>

--- a/content/people/zhiya-xu/index.md
+++ b/content/people/zhiya-xu/index.md
@@ -18,9 +18,6 @@ sections:
                 <div class="profile-card">
                   <div class="profile-image-container">
                     <img src="avatar-team.jpg" alt="Zhiya Xu" class="profile-image">
-                    <div class="profile-badge">
-                      <i class="fas fa-graduation-cap"></i>
-                    </div>
                   </div>
                   <div class="profile-info">
                     <h1 class="profile-name">Zhiya Xu</h1>


### PR DESCRIPTION
## Summary
- delete profile badge sections on homepage and profile pages
- remove deprecated `.profile-badge` styles from CSS/SCSS

## Testing
- `hugo --minify` *(fails: command not found)*
- `go install github.com/gohugoio/hugo@v0.134.3` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685963015d3083238234caf902a71ecd